### PR TITLE
fix: remove markdownlint rules unexisting

### DIFF
--- a/eslint/config/index.mjs
+++ b/eslint/config/index.mjs
@@ -1458,7 +1458,7 @@ export function createMarkdownConfig() {
         'markdownlint/md021': 'error', // Multiple spaces inside hashes on closed atx style heading
         'markdownlint/md022': ['error', { lines_above: 1, lines_below: 1 }], // Headings surrounded by blank lines
         'markdownlint/md023': 'error', // Headings must start at the beginning of the line
-        'markdownlint/md024': ['error', { allow_different_nesting: true }], // Multiple headings with the same content
+        'markdownlint/md024': 'error', // Multiple headings with the same content
         'markdownlint/md025': ['error', { level: 1 }], // Multiple top level headings
         'markdownlint/md026': ['error', { punctuation: '.,;:!?' }], // Trailing punctuation in heading
         'markdownlint/md027': 'error', // Multiple spaces after blockquote symbol
@@ -1488,9 +1488,6 @@ export function createMarkdownConfig() {
         'markdownlint/md048': ['error', { style: 'backtick' }], // Code fence style
         'markdownlint/md049': ['error', { style: 'underscore' }], // Emphasis style
         'markdownlint/md050': ['error', { style: 'asterisk' }], // Strong style
-        'markdownlint/md051': 'error', // Link fragments should be valid
-        'markdownlint/md052': 'error', // Reference links and images should use a label
-        'markdownlint/md053': 'error', // Link and image reference definitions should be needed
       },
     },
 


### PR DESCRIPTION
# PLYENG-189: Fix ESLint rule errors in @plyaz/devtools base config

## Jira Ticket

- **Ticket**: [PLYENG-189](https://plyaz.atlassian.net/browse/PLYAZ-189)
- **Epic**: [PLYENG-94](https://plyaz.atlassian.net/browse/PLYAZ-94)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature with API changes or that would cause existing functionality to not work as expected)
- [x] 🔨 Refactoring (code improvement with no functional changes)
- [ ] 📚 Documentation update
- [ ] 🧪 Test update
- [ ] 🛠️ Build/CI update
- [ ] 🧹 Chore (dependency updates, maintenance tasks, etc.)

## Implementation
- Removed invalid rules: `md051`, `md052`, `md053` (not supported by the plugin). [Rule list](https://github.com/paweldrozd/eslint-plugin-markdownlint/tree/main/lib/rules)
- Fixed `md024` by removing the unsupported `allow_different_nesting` option.

[PLYENG-189]: https://plyaz.atlassian.net/browse/PLYENG-189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLYENG-94]: https://plyaz.atlassian.net/browse/PLYENG-94?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ